### PR TITLE
ingest: use redis for processing cache

### DIFF
--- a/src/nv_ingest/schemas/processing_job_schema.py
+++ b/src/nv_ingest/schemas/processing_job_schema.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from enum import Enum
+
+class ConversionStatus(str, Enum):
+    IN_PROGRESS = "in_progress"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+class ProcessingJob(BaseModel):
+    submitted_job_id: str
+    filename: str
+    content: str = ""
+    status: ConversionStatus
+    error: str | None = None
+

--- a/src/nv_ingest/service/impl/ingest/redis_ingest_service.py
+++ b/src/nv_ingest/service/impl/ingest/redis_ingest_service.py
@@ -15,12 +15,12 @@ import uuid
 from json import JSONDecodeError
 from typing import Any
 
-from redis import RedisError
-
+from typing import List
 from nv_ingest.schemas import validate_ingest_job
 from nv_ingest.schemas.message_wrapper_schema import MessageWrapper
 from nv_ingest.service.meta.ingest.ingest_service_meta import IngestServiceMeta
 from nv_ingest.util.message_brokers.redis.redis_client import RedisClient
+from nv_ingest.schemas.processing_job_schema import ProcessingJob
 
 logger = logging.getLogger("uvicorn")
 
@@ -49,6 +49,7 @@ class RedisIngestService(IngestServiceMeta):
         self._redis_hostname = redis_hostname
         self._redis_port = redis_port
         self._redis_task_queue = redis_task_queue
+        self._cache_prefix = "processing_cache:"
 
         self._ingest_client = RedisClient(host=self._redis_hostname, port=self._redis_port,
                                           max_pool_size=self._concurrency_level)
@@ -81,3 +82,28 @@ class RedisIngestService(IngestServiceMeta):
             raise TimeoutError()
 
         return message
+    
+    async def set_processing_cache(self, job_id: str, jobs_data: List[ProcessingJob]) -> None:
+        """Store processing jobs data using simple key-value"""
+        cache_key = f"{self._cache_prefix}{job_id}"
+        try:
+            self._ingest_client.get_client().set(
+                cache_key,
+                json.dumps([job.dict() for job in jobs_data]),
+                ex=3600
+            )
+        except Exception as err:
+            logger.error(f"Error setting cache for {cache_key}: {err}")
+            raise
+    
+    async def get_processing_cache(self, job_id: str) -> List[ProcessingJob]:
+        """Retrieve processing jobs data using simple key-value"""
+        cache_key = f"{self._cache_prefix}{job_id}"
+        try:
+            data = self._ingest_client.get_client().get(cache_key)
+            if data is None:
+                return []
+            return [ProcessingJob(**job) for job in json.loads(data)]
+        except Exception as err:
+            logger.error(f"Error getting cache for {cache_key}: {err}")
+            raise

--- a/src/nv_ingest/service/meta/ingest/ingest_service_meta.py
+++ b/src/nv_ingest/service/meta/ingest/ingest_service_meta.py
@@ -10,8 +10,10 @@
 
 from abc import ABC
 from abc import abstractmethod
+from typing import List
 
 from nv_ingest.schemas.message_wrapper_schema import MessageWrapper
+from nv_ingest.schemas.processing_job_schema import ProcessingJob
 
 
 class IngestServiceMeta(ABC):
@@ -22,3 +24,11 @@ class IngestServiceMeta(ABC):
     @abstractmethod
     async def fetch_job(self, job_id: str):
         """Abstract method for fetching job from ingestion service based on job_id"""
+
+    @abstractmethod
+    async def set_processing_cache(self, job_id: str, jobs_data: List[ProcessingJob]) -> None:
+        """Abstract method for setting processing cache"""
+    
+    @abstractmethod
+    async def get_processing_cache(self, job_id: str) -> List[ProcessingJob]:
+        """Abstract method for getting processing cache"""


### PR DESCRIPTION
The `processing_cache` used for the ingest service is not shared across uvinicorn workers. This results in the status endpoint returning 500's because the job_id dne in the selected workers `processing_cache` variable.

This PR uses redis to store and retrieve the processing_cache to ensure state is shared across the workers.